### PR TITLE
Feat: Add support for warning color

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@ auro-icon provides users a way to use the Auro Icons by simply passing in the ca
 |------------------|------------------|-----------|--------------------------------------------------|
 | `accent`         | `accent`         | `Boolean` | Sets the icon to use the accent style.           |
 | `advisory`       | `advisory`       | `boolean` |                                                  |
+| `warning`        | `warning`        | `boolean` | Sets the icon to use the warning style.          |
 | `category`       | `category`       | `String`  | The category of the icon you are looking for. See https://auro.alaskaair.com/icons/usage. |
 | `disabled`       | `disabled`       | `Boolean` | Sets the icon to use the disabled style.         |
 | `emphasis`       | `emphasis`       | `Boolean` | Sets the icon to use the emphasis style.         |

--- a/src/auro-icon.js
+++ b/src/auro-icon.js
@@ -74,6 +74,10 @@ class AuroIcon extends AuroElement {
         type: Boolean,
         reflect: true
       },
+      warning: {
+        type: Boolean,
+        reflect: true
+      },
       onDark: {
         type: Boolean,
         reflect: true
@@ -125,7 +129,8 @@ class AuroIcon extends AuroElement {
       'disabled': this.disabled,
       'error': this.error,
       'success': this.success,
-      'advisory': this.advisory
+      'advisory': this.advisory,
+      'warning': this.warning
     }
 
     return html`

--- a/src/style.scss
+++ b/src/style.scss
@@ -45,11 +45,11 @@
   }
 
   .advisory {
-    color: var(--auro-color-alert-advisory-on-light)
+    color: var(--auro-color-alert-advisory-on-light);
   }
 
   .warning {
-    color: var(--auro-color-alert-warning-on-light)
+    color: var(--auro-color-alert-warning-on-light);
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -47,6 +47,10 @@
   .advisory {
     color: var(--auro-color-alert-advisory-on-light)
   }
+
+  .warning {
+    color: var(--auro-color-alert-warning-on-light)
+  }
 }
 
 :host([onDark]) {
@@ -75,6 +79,10 @@
   }
 
   .advisory {
-    color: var(--auro-color-alert-advisory-on-dark)
+    color: var(--auro-color-alert-advisory-on-dark);
+  }
+
+  .warning {
+    color: var(--auro-color-alert-warning-on-dark);
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR adds support for the auro warning color as an attribute 'warning' on the auro-icon.

## Summary:

As an alaskaair.com developer, I want to be able to use icons which take advantage of the warning color from auro. This PR enables that by simply adding a new attribute to the auro-icon component

## Type of change:

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
