### PR TITLE
fix: add custom property fallbacks for IE11

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -13,6 +13,8 @@
 // Support for auroElement styles
 @import "./node_modules/@alaskaairux/orion-web-core-style-sheets/dist/auroElement/auroElement";
 
+@import "./node_modules/@alaskaairux/icons/dist/icons";
+
 :host {
   color: currentColor;
   display: inline-block;

--- a/test/auro-icon.test.js
+++ b/test/auro-icon.test.js
@@ -3,7 +3,21 @@
 /* eslint-disable one-var */
 /* eslint-disable no-undef */
 import { fixture, html, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
 import '../src/auro-icon.js';
+
+const fetchStub = sinon.stub(window, 'fetch');
+
+function mockIconResponse(body = "") {
+  return new window.Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-type': 'application/json' }
+ });
+}
+
+beforeEach(() => {
+  fetchStub.resolves(mockIconResponse("<svg></svg>"));
+});
 
 describe('auro-icon', () => {
   it('icon is set', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

The component was not importing the custom property fallbacks needed for IE11. This caused the SVGs to appear way too large.

This also updates the tests to use a stubbed fetch so that we are not reliant on unpkg for tests to succeed.

Before:
![image](https://user-images.githubusercontent.com/4992896/94957050-f9ac5a80-04a1-11eb-8e88-7ce5f0dc5f45.png)

After:
![image](https://user-images.githubusercontent.com/4992896/94957074-0630b300-04a2-11eb-90cb-8896082050b2.png)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
