### PR TITLE
fix: improve performance by deduping fetch requests for SVG icons

### DIFF
--- a/src/auro-icon.js
+++ b/src/auro-icon.js
@@ -8,6 +8,7 @@ import { html, css } from "lit-element";
 import { classMap } from 'lit-html/directives/class-map';
 import AuroElement from '@alaskaairux/orion-web-core-style-sheets/dist/auroElement/auroElement';
 import penguin from '@alaskaairux/icons/dist/icons/interface/penguin_es6.js';
+import cacheFetch from './cacheFetch';
 
 // Import touch detection lib
 import "focus-visible/dist/focus-visible.min.js";
@@ -112,20 +113,18 @@ class AuroIcon extends AuroElement {
    */
   async fetchIcon(category, name) {
     const uri = 'https://unpkg.com/@alaskaairux/icons@latest/dist';
-    let icon = '';
+    let iconHTML = '';
 
     if (category === 'logos') {
-      icon = await fetch(`${uri}/${category}/${name}.svg`);
+      iconHTML = await cacheFetch(`${uri}/${category}/${name}.svg`);
     } else if (this.alaska) {
-      icon = await fetch(`${uri}/restricted/AS.svg`);
+      iconHTML = await cacheFetch(`${uri}/restricted/AS.svg`);
     } else if (this.alaskaTagline) {
-      icon = await fetch(`${uri}/restricted/AS-tagline.svg`);
+      iconHTML = await cacheFetch(`${uri}/restricted/AS-tagline.svg`);
     } else {
-      icon = await fetch(`${uri}/icons/${category}/${name}.svg`);
+      iconHTML = await cacheFetch(`${uri}/icons/${category}/${name}.svg`);
     }
 
-
-    const iconHTML = await icon.text();
     const dom = new DOMParser().parseFromString(iconHTML, 'text/html');
 
     return dom.body.querySelector('svg');

--- a/src/cacheFetch.js
+++ b/src/cacheFetch.js
@@ -1,0 +1,27 @@
+const _fetchMap = new Map();
+
+/**
+ * A callback to parse Response body.
+ * 
+ * @callback ResponseParser
+ * @param {Fetch.Response} response
+ * @returns {Promise}
+ */
+
+/**
+ * A minimal in-memory map to de-duplicate Fetch API media requests.
+ * 
+ * @param {String} uri
+ * @param {Object} [options={}]
+ * @param {ResponseParser} [options.responseParser=(response) => response.text()]
+ * @returns {Promise}
+ */
+const cacheFetch = (uri, options = {}) => {
+  const responseParser = options.responseParser || ((response) => response.text());
+  if (!_fetchMap.has(uri)) {
+    _fetchMap.set(uri, fetch(uri).then(responseParser));
+  }
+  return _fetchMap.get(uri);  
+}
+
+export default cacheFetch;

--- a/test/auro-icon.test.js
+++ b/test/auro-icon.test.js
@@ -71,7 +71,7 @@ describe('auro-icon', () => {
     expect(svg).to.not.be.null;
   });
 
-  it ('does not duplicate requests for same icon source', async () => {
+  it('does not duplicate requests for same icon source', async () => {
     const el = await (fixture(html`
       <auro-icon category="interface" name="chevron-up" emphasis></auro-icon>
       <auro-icon category="interface" name="chevron-up" emphasis></auro-icon>

--- a/test/auro-icon.test.js
+++ b/test/auro-icon.test.js
@@ -16,6 +16,7 @@ function mockIconResponse(body = "") {
 }
 
 beforeEach(() => {
+  fetchStub.resetHistory();
   fetchStub.resolves(mockIconResponse("<svg></svg>"));
 });
 
@@ -68,6 +69,17 @@ describe('auro-icon', () => {
     expect(div).to.not.have.class('accent');
     expect(div).to.not.have.class('disabled');
     expect(svg).to.not.be.null;
+  });
+
+  it ('does not duplicate requests for same icon source', async () => {
+    const el = await (fixture(html`
+      <auro-icon category="interface" name="chevron-up" emphasis></auro-icon>
+      <auro-icon category="interface" name="chevron-up" emphasis></auro-icon>
+    `));
+
+    await waitUntil(() => el.svg, 'Element did not become ready');
+
+    expect(fetch).to.be.calledOnceWith(sinon.match('icons/interface/chevron-up.svg'));
   });
 
   it('auro-icon is using emphasis style', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Partially Fixes:** #13 

## Summary:

We often use JavaScript to fetch and inline SVGs (if I'm reading the history right, the SVG 2.0 spec missed an iteration in web development that brought us CORS). When an `img[src]` is used several times on a page, the browser makes a single network request and resolves the image source to each instance. The same is not true for Fetch API. By adding a minimal map, we're simulating this browser behavior and preventing excessive network calls for icon SVGs.

Before:
<img width="1103" alt="Screen Shot 2020-11-28 at 12 33 41 PM" src="https://user-images.githubusercontent.com/4391579/100526575-e99db800-317e-11eb-9bb1-3258739e2709.png">

After:
<img width="1110" alt="Screen Shot 2020-11-28 at 1 13 27 PM" src="https://user-images.githubusercontent.com/4391579/100526574-e7d3f480-317e-11eb-8861-142c1899a4fa.png">

## Type of change:

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
