### PR TITLE
fix: correct naming in function for exporting css parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.9.2/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-icon@6.0.3/dist/auro-icon__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-icon@6.1.0/dist/auro-icon__bundled.js" type="module"></script>
 ```
 
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/demo/api.min.js
+++ b/demo/api.min.js
@@ -435,7 +435,7 @@ class AuroIcon extends BaseIcon {
    * @returns {void} Exposes CSS parts for styling from parent components.
    */
   exposeCssParts() {
-    this.setAttribute('exportparts', 'iconSvg:svg');
+    this.setAttribute('exportparts', 'svg:iconSvg');
   }
 
   // function that renders the HTML and CSS into  the scope of the component

--- a/demo/index.min.js
+++ b/demo/index.min.js
@@ -435,7 +435,7 @@ class AuroIcon extends BaseIcon {
    * @returns {void} Exposes CSS parts for styling from parent components.
    */
   exposeCssParts() {
-    this.setAttribute('exportparts', 'iconSvg:svg');
+    this.setAttribute('exportparts', 'svg:iconSvg');
   }
 
   // function that renders the HTML and CSS into  the scope of the component

--- a/src/auro-icon.js
+++ b/src/auro-icon.js
@@ -182,7 +182,7 @@ export class AuroIcon extends BaseIcon {
    * @returns {void} Exposes CSS parts for styling from parent components.
    */
   exposeCssParts() {
-    this.setAttribute('exportparts', 'iconSvg:svg');
+    this.setAttribute('exportparts', 'svg:iconSvg');
   }
 
   // function that renders the HTML and CSS into  the scope of the component


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix the naming in the 'exposeCssParts' function to ensure correct CSS part exports and update the README.md with the latest auro-icon module version.

Bug Fixes:
- Correct the naming in the 'exposeCssParts' function to properly export CSS parts for styling.

Documentation:
- Update the README.md to reflect the new version of the auro-icon module.