### PR TITLE
Update WebCoreStyleSheets to work with Node 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.9.2/dist/tokens/CSSCustomProperties.css" />
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@6.0.1/dist/bundled/essentials.css" />
 <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-icon@6.1.7/dist/auro-icon__bundled.js" type="module"></script>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-icon",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-icon",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@alaskaairux/icons": "^4.44.1",
         "@aurodesignsystem/design-tokens": "^4.13.0",
         "@aurodesignsystem/eslint-config": "^1.3.3",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1",
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@open-wc/testing": "^4.0.0",
@@ -67,7 +67,7 @@
       "peerDependencies": {
         "@alaskaairux/icons": "^4.43.0",
         "@aurodesignsystem/design-tokens": "^4.9.2",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1"
       }
     },
     "node_modules/@alaskaairux/icons": {
@@ -268,20 +268,19 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-5.1.2.tgz",
-      "integrity": "sha512-pokV/Mf83oOCac8jjFjqjaHxWoaMrakPVxgpdG6eVSd3Tj5EiMjb3DlYGzOpl57R+s026gJtqfwdAPoj23b3og==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-6.0.1.tgz",
+      "integrity": "sha512-Q+bD0zio8dRUjSgRFBeuHmV6mSfQuLVpF+obDC0XCDcD7mbzXqJjRM/vEexy7soX4R/lsu1fKcngolgtC3Nr4g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.3.0"
+        "chalk": "^5.4.1"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20 || ^22"
       },
       "peerDependencies": {
-        "@aurodesignsystem/design-tokens": "^4.1.1",
+        "@aurodesignsystem/design-tokens": "^4.9.1",
         "sass": "^1.42.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "peerDependencies": {
     "@alaskaairux/icons": "^4.43.0",
     "@aurodesignsystem/design-tokens": "^4.9.2",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1"
   },
   "devDependencies": {
     "@alaskaairux/icons": "^4.44.1",
     "@aurodesignsystem/design-tokens": "^4.13.0",
     "@aurodesignsystem/eslint-config": "^1.3.3",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1",
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
Update WebCoreStyleSheets version for Node 22 compatibility.

Related to: https://github.com/AlaskaAirlines/auro-alert/issues/88