### PR TITLE
Add muted onDark styles

### DIFF
--- a/apiExamples/onDark.html
+++ b/apiExamples/onDark.html
@@ -1,4 +1,5 @@
 <span style="color: var(--ds-basic-color-texticon-inverse)">
   <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
+  <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
 </span>

--- a/demo/api.md
+++ b/demo/api.md
@@ -175,12 +175,13 @@ Mono-color icons support the following attributes to illustrate visual state.
 
 All compatible with `onDark` attribute.
 
-<div class="exampleWrapper" style="background: repeating-linear-gradient(45deg, var(--ds-basic-color-surface-inverse, #{$ds-basic-color-surface-inverse}), var(--ds-basic-color-surface-inverse, #{$ds-basic-color-surface-inverse}) 10px, var(--ds-basic-color-surface-inverse-subtle, #{$ds-basic-color-surface-inverse-subtle}) 10px, var(--ds-basic-color-surface-inverse-subtle, #{$ds-basic-color-surface-inverse-subtle}) 20px);">
+<div class="exampleWrapper--ondark">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark.html) -->
   <!-- The below content is automatically added from ../apiExamples/onDark.html -->
   <span style="color: var(--ds-basic-color-texticon-inverse)">
     <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
     <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
+    <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
   </span>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -193,6 +194,7 @@ All compatible with `onDark` attribute.
 <span style="color: var(--ds-basic-color-texticon-inverse)">
   <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
+  <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
 </span>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -75,7 +75,7 @@ Mono-color icons support the following attributes to illustrate visual state.
 
 All compatible with `onDark` attribute.
 
-<div class="exampleWrapper" style="background: repeating-linear-gradient(45deg, var(--ds-basic-color-surface-inverse, #{$ds-basic-color-surface-inverse}), var(--ds-basic-color-surface-inverse, #{$ds-basic-color-surface-inverse}) 10px, var(--ds-basic-color-surface-inverse-subtle, #{$ds-basic-color-surface-inverse-subtle}) 10px, var(--ds-basic-color-surface-inverse-subtle, #{$ds-basic-color-surface-inverse-subtle}) 20px);">
+<div class="exampleWrapper--ondark">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@aurodesignsystem/auro-icon",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-icon",
-      "version": "7.0.1",
+      "version": "8.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@alaskaairux/icons": "5.3.0",
         "@aurodesignsystem/auro-library": "^4.1.0",
-        "@aurodesignsystem/design-tokens": "^5.6.1",
+        "@aurodesignsystem/design-tokens": "^5.8.2",
         "@aurodesignsystem/webcorestylesheets": "6.1.0",
         "chalk": "^5.4.1",
         "lit": "^3.2.1"
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-5.6.1.tgz",
-      "integrity": "sha512-C4TAdjMwLCb0BC7yf4b1mBdMPWC9EC6dzFjbU/T7lAP7k+VKCthX73OIrhXXLx1hbGQr6VhoXjXyNv3fpyW54w==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-5.8.2.tgz",
+      "integrity": "sha512-tFZqb+b3TIv1nCBtNR7ubRv19n1sRis0MM5T+eU6X6fqdSUlT3nNfJfW5y5qxLdpSzcEhg/DPaCg0sakipakLw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@alaskaairux/icons": "5.3.0",
     "@aurodesignsystem/auro-library": "^4.1.0",
-    "@aurodesignsystem/design-tokens": "^5.6.1",
+    "@aurodesignsystem/design-tokens": "^5.8.2",
     "@aurodesignsystem/webcorestylesheets": "6.1.0",
     "chalk": "^5.4.1",
     "lit": "^3.2.1"

--- a/src/color.scss
+++ b/src/color.scss
@@ -106,5 +106,9 @@
 }
 
 :host([onDark][variant="disabled"]) {
-  --ds-auro-icon-color: var(--ds-basic-color-texticon-disabled-inverse, #{$ds-basic-color-texticon-disabled-inverse});
+  --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse-disabled, #{$ds-basic-color-texticon-inverse-disabled});
+}
+
+:host([onDark][variant="muted"]) {
+  --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse-muted, #{$ds-basic-color-texticon-inverse-muted});
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add muted variant support for icons with onDark attribute

New Features:
- Introduce a new 'muted' variant for icons when used with the onDark attribute

Enhancements:
- Update design tokens dependency to support new muted inverse color styles

Documentation:
- Update documentation and API examples to showcase the new muted onDark icon variant