### PR TITLE
Add onDark version of `statusError` variant

### DIFF
--- a/apiExamples/onDark.html
+++ b/apiExamples/onDark.html
@@ -2,4 +2,5 @@
   <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
+  <auro-icon category="interface" name="pin-trip" onDark variant="statusError"></auro-icon> status error<br />
 </span>

--- a/demo/api.md
+++ b/demo/api.md
@@ -182,6 +182,7 @@ All compatible with `onDark` attribute.
     <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
     <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
     <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
+    <auro-icon category="interface" name="pin-trip" onDark variant="statusError"></auro-icon> status error<br />
   </span>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -195,6 +196,7 @@ All compatible with `onDark` attribute.
   <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
   <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
+  <auro-icon category="interface" name="pin-trip" onDark variant="statusError"></auro-icon> status error<br />
 </span>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/src/color.scss
+++ b/src/color.scss
@@ -112,3 +112,7 @@
 :host([onDark][variant="muted"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse-muted, #{$ds-basic-color-texticon-inverse-muted});
 }
+
+:host([onDark][variant="statusError"]) {
+  --ds-auro-icon-color: var(--ds-advanced-color-state-error-inverse, #{$ds-advanced-color-state-error-inverse});
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add support for an onDark 'statusError' variant on auro-icon and update documentation to include the new variant

New Features:
- Introduce CSS rule for onDark variant="statusError" to apply inverse error state coloring

Documentation:
- Add statusError variant examples to demo/api.md and apiExamples/onDark.html