### PR TITLE
feat: add appearance attr and deprecate onDark #210

### DIFF
--- a/apiExamples/inverseAppearance.html
+++ b/apiExamples/inverseAppearance.html
@@ -1,0 +1,6 @@
+<span style="color: var(--ds-basic-color-texticon-inverse)">
+  <auro-icon category="interface" name="pin-trip" appearance="inverse"></auro-icon> default<br />
+  <auro-icon category="interface" name="pin-trip" appearance="inverse" variant="disabled"></auro-icon> disabled<br />
+  <auro-icon category="interface" name="pin-trip" appearance="inverse" variant="muted"></auro-icon> muted<br />
+  <auro-icon category="interface" name="pin-trip" appearance="inverse" variant="statusError"></auro-icon> status error<br />
+</span>

--- a/apiExamples/onDark.html
+++ b/apiExamples/onDark.html
@@ -1,6 +1,0 @@
-<span style="color: var(--ds-basic-color-texticon-inverse)">
-  <auro-icon category="interface" name="pin-trip" onDark></auro-icon> default<br />
-  <auro-icon category="interface" name="pin-trip" onDark variant="disabled"></auro-icon> disabled<br />
-  <auro-icon category="interface" name="pin-trip" onDark variant="muted"></auro-icon> muted<br />
-  <auro-icon category="interface" name="pin-trip" onDark variant="statusError"></auro-icon> status error<br />
-</span>

--- a/demo/alaska.md
+++ b/demo/alaska.md
@@ -15,18 +15,20 @@ import "@alaskaairux/auro-icon";
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
   <auro-alaska style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>
 <div class="exampleWrapper--ondark">
-  <auro-alaska onDark style="width: 192px"></auro-alaska>
+  <auro-alaska appearance="inverse" style="width: 192px"></auro-alaska>
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
-  <auro-alaska onDark style="width: 192px"></auro-alaska>
+  <auro-alaska appearance="inverse" style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>
@@ -40,18 +42,20 @@ Using the `official` property will display the Alaska Airlines logo with the off
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
   <auro-alaska official style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>
 <div class="exampleWrapper--ondark">
-  <auro-alaska official ondark style="width: 192px"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px"></auro-alaska>
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
-  <auro-alaska official ondark style="width: 192px"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>
@@ -68,6 +72,7 @@ The Alaska Airline logo has a preferred version of the logo depending in the siz
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
   <auro-alaska style="width: 72px"></auro-alaska>
   <auro-alaska style="width: 108px"></auro-alaska>
@@ -84,6 +89,7 @@ The Alaska Airline logo has a preferred version of the logo depending in the siz
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
+
   ```html
   <auro-alaska official style="width: 72px"></auro-alaska>
   <auro-alaska official style="width: 108px"></auro-alaska>

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@ auro-icon provides users a way to use the Auro Icons by simply passing in the ca
 
 | Property         | Attribute        | Type      | Default     | Description                                      |
 |------------------|------------------|-----------|-------------|--------------------------------------------------|
+| `appearance`     | `appearance`     | `string`  | "'default'" | Defines whether the button will be on lighter or darker backgrounds. |
 | `ariaHidden`     | `ariaHidden`     | `string`  |             | Set aria-hidden value. Default is `true`. Option is `false`. |
 | `category`       | `category`       | `string`  |             | The category of the icon you are looking for. See https://auro.alaskaair.com/icons/usage. |
 | `customColor`    | `customColor`    | `boolean` |             | Allows custom color to be set.                   |
@@ -15,7 +16,7 @@ auro-icon provides users a way to use the Auro Icons by simply passing in the ca
 | `hiddenVisually` | `hiddenVisually` | `Boolean` |             | If present, the component will be hidden visually, but still read by screen readers |
 | `label`          | `label`          | `boolean` |             | Exposes content in slot as icon label.           |
 | `name`           | `name`           | `string`  |             | The name of the icon you are looking for without the file extension. See https://auro.alaskaair.com/icons/usage. |
-| `onDark`         | `onDark`         | `boolean` | false       | Set value for on-dark version of auro-icon.      |
+| `onDark`         | `onDark`         | `boolean` | false       | DEPRECATED - use `appearance` instead.           |
 | `variant`        | `variant`        | `string`  | "undefined" | The style of the icon. The accepted variants are `accent1`, `disabled`, `muted`, `statusDefault`, `statusInfo`, `statusSuccess`, `statusWarning`, `statusError`, `statusInfoSubtle`, `statusSuccessSubtle`, `statusWarningSubtle`, `statusErrorSubtle`, `fareBasicEconomy`, `fareBusiness`, `fareEconomy`, `fareFirst`, `farePremiumEconomy`, `tierOneWorldEmerald`, `tierOneWorldSapphire`, `tierOneWorldRuby`. |
 
 ## Slots

--- a/docs/partials/alaska.md
+++ b/docs/partials/alaska.md
@@ -24,14 +24,14 @@ import "@alaskaairux/auro-icon";
 </auro-accordion>
 
 <div class="exampleWrapper--ondark">
-  <auro-alaska onDark style="width: 192px"></auro-alaska>
+  <auro-alaska appearance="inverse" style="width: 192px"></auro-alaska>
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
   ```html
-  <auro-alaska onDark style="width: 192px"></auro-alaska>
+  <auro-alaska appearance="inverse" style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>
@@ -54,14 +54,14 @@ Using the `official` property will display the Alaska Airlines logo with the off
 </auro-accordion>
 
 <div class="exampleWrapper--ondark">
-  <auro-alaska official ondark style="width: 192px"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px"></auro-alaska>
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
   ```html
-  <auro-alaska official ondark style="width: 192px"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px"></auro-alaska>
   ```
 
 </auro-accordion>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -71,19 +71,19 @@ Mono-color icons support the following attributes to illustrate visual state.
 
 </auro-accordion>
 
-#### onDark visual state
+#### Visual state on Dark background
 
-All compatible with `onDark` attribute.
+All compatible with `appearance="inverse"` attribute.
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearance.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onDark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearance.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "lit": "^3.3.0"
       },
       "devDependencies": {
-        "@alaskaairux/icons": "5.3.0",
+        "@alaskaairux/icons": "5.10.0",
         "@aurodesignsystem/auro-cli": "^3.0.3",
         "@aurodesignsystem/auro-config": "^1.3.0",
         "@aurodesignsystem/auro-library": "^5.5.3",
-        "@aurodesignsystem/design-tokens": "^8.4.4",
-        "@aurodesignsystem/webcorestylesheets": "10.0.4",
+        "@aurodesignsystem/design-tokens": "^8.5.0",
+        "@aurodesignsystem/webcorestylesheets": "10.1.1",
         "husky": "^9.1.7",
         "sinon": "^20.0.0"
       },
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@alaskaairux/icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-5.3.0.tgz",
-      "integrity": "sha512-LIR7YCxsxqGYov1xhuD0A/nY9pp4OSaKqcWLx5JBJF6xX/XadL71C9z+YFmVLbxX0M8gY2T1Tz8iyf353MT6JQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-5.10.0.tgz",
+      "integrity": "sha512-du+TE5sVsg4cufKcJzsNfhhr/VrWdSPaC5YDquvoNtZFJDjhKr8GwNaaJzc0gEXsOSyRpcoW5wQYPt6qI9vNAw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.4.tgz",
-      "integrity": "sha512-5ZH7Np2atWw/54NMBvCgBc2j0AF9oyftEleLUr1zEcgbuUWc3ByTnQeFKUsPPxsKJ5kpT9x4JVVBG9pbMu2xIA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.5.0.tgz",
+      "integrity": "sha512-RygKVYYU5c9d78MXRxXSO+VQTmpqzvyxk+MgsmtPex6eG5R++PuJbCTK8UYOSG9pUdPV11cX2/avtgJIrJPPJw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -581,14 +581,14 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.4.tgz",
-      "integrity": "sha512-hUAsrXCiUpOfwkMZ2gI+oKY9oQRNQfeC1Edbf7OBqfhAPaXLbZ3kEivoEYqyI9XOC7Bf0dOdObHXIXAdrOynXQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.1.1.tgz",
+      "integrity": "sha512-aD0NKjmDgavZBSaFkfKNYLZwIoKH2iOf/m19kCnQklNqae4jceGV5vVi8Qyx6MH2/02rn4SuiaDXjCdA6tMX2g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.4.1",
+        "@aurodesignsystem/design-tokens": "8.5.0",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -596,21 +596,6 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
-      }
-    },
-    "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.1.tgz",
-      "integrity": "sha512-eL3WJAroHWrkoRi/5h53auyFzNiS57mxfdjML8C6nf8wV+KtJvwiNU0oaGsLHPAzicLPxuptkEM04oTo+V8LQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.6"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type": "git",
     "url": "https://github.com/AlaskaAirlines/auro-icon"
   },
+  "type": "module",
   "main": "dist/registered.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -23,10 +24,10 @@
     "lit": "^3.3.0"
   },
   "devDependencies": {
-    "@alaskaairux/icons": "5.3.0",
+    "@alaskaairux/icons": "5.10.0",
     "@aurodesignsystem/auro-library": "^5.5.3",
-    "@aurodesignsystem/design-tokens": "^8.4.4",
-    "@aurodesignsystem/webcorestylesheets": "10.0.4",
+    "@aurodesignsystem/design-tokens": "^8.5.0",
+    "@aurodesignsystem/webcorestylesheets": "10.1.1",
     "@aurodesignsystem/auro-cli": "^3.0.3",
     "@aurodesignsystem/auro-config": "^1.3.0",
     "sinon": "^20.0.0",

--- a/src/baseIcon.js
+++ b/src/baseIcon.js
@@ -18,6 +18,7 @@ export default class BaseIcon extends AuroElement {
   constructor() {
     super();
     this.onDark = false;
+    this.appearance = "default";
   }
 
   // function to define props used within the scope of this component
@@ -26,11 +27,21 @@ export default class BaseIcon extends AuroElement {
       ...AuroElement.properties,
 
       /**
-       * Set value for on-dark version of auro-icon.
+       * DEPRECATED - use `appearance` instead.
        */
       onDark: {
         type: Boolean,
         reflect: true,
+      },
+
+      /**
+       * Defines whether the button will be on lighter or darker backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
       },
 
       /**

--- a/src/styles/alaskaStyle.scss
+++ b/src/styles/alaskaStyle.scss
@@ -19,6 +19,7 @@
   }
 }
 
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   --ds-auro-alaska-color: #FFF; // Hardcoded hex value for logo in order to prevent color change
 }

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -14,103 +14,127 @@
   color: inherit;
 }
 
-:host(:not([onDark])[variant="accent1"]) {
+:host(:not([onDark])[variant="accent1"]),
+:host(:not([appearance="inverse"])[variant="accent1"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-accent1, #{v.$ds-basic-color-texticon-accent1});
 }
 
-:host(:not([onDark])[variant="disabled"]) {
+:host(:not([onDark])[variant="disabled"]),
+:host(:not([appearance="inverse"])[variant="disabled"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-disabled, #{v.$ds-basic-color-texticon-disabled});
 }
 
-:host(:not([onDark])[variant="muted"]) {
+:host(:not([onDark])[variant="muted"]),
+:host(:not([appearance="inverse"])[variant="muted"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-muted, #{v.$ds-basic-color-texticon-muted});
 }
 
 /* Status Styles */
-:host(:not([onDark])[variant="statusDefault"]) {
+:host(:not([onDark])[variant="statusDefault"]),
+:host(:not([appearance="inverse"])[variant="statusDefault"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-default, #{v.$ds-basic-color-status-default});
 }
 
-:host(:not([onDark])[variant="statusInfo"]) {
+:host(:not([onDark])[variant="statusInfo"]),
+:host(:not([appearance="inverse"])[variant="statusInfo"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-info, #{v.$ds-basic-color-status-info});
 }
 
-:host(:not([onDark])[variant="statusSuccess"]) {
+:host(:not([onDark])[variant="statusSuccess"]),
+:host(:not([appearance="inverse"])[variant="statusSuccess"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-success, #{v.$ds-basic-color-status-success});
 }
 
-:host(:not([onDark])[variant="statusWarning"]) {
+:host(:not([onDark])[variant="statusWarning"]),
+:host(:not([appearance="inverse"])[variant="statusWarning"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-warning, #{v.$ds-basic-color-status-warning});
 }
 
-:host(:not([onDark])[variant="statusError"]) {
+:host(:not([onDark])[variant="statusError"]),
+:host(:not([appearance="inverse"])[variant="statusError"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-error, #{v.$ds-basic-color-status-error});
 }
 
 /* Subtle Status Styles */
-:host(:not([onDark])[variant="statusInfoSubtle"]) {
+:host(:not([onDark])[variant="statusInfoSubtle"]),
+:host(:not([appearance="inverse"])[variant="statusInfoSubtle"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-info-subtle, #{v.$ds-basic-color-status-info-subtle});
 }
 
-:host(:not([onDark])[variant="statusSuccessSubtle"]) {
+:host(:not([onDark])[variant="statusSuccessSubtle"]),
+:host(:not([appearance="inverse"])[variant="statusSuccessSubtle"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-success-subtle, #{v.$ds-basic-color-status-success-subtle});
 }
 
-:host(:not([onDark])[variant="statusWarningSubtle"]) {
+:host(:not([onDark])[variant="statusWarningSubtle"]),
+:host(:not([appearance="inverse"])[variant="statusWarningSubtle"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-warning-subtle, #{v.$ds-basic-color-status-warning-subtle});
 }
 
-:host(:not([onDark])[variant="statusErrorSubtle"]) {
+:host(:not([onDark])[variant="statusErrorSubtle"]),
+:host(:not([appearance="inverse"])[variant="statusErrorSubtle"]) {
   --ds-auro-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
 }
 
 /* Fare Classes */
-:host(:not([onDark])[variant="fareBasicEconomy"]) {
+:host(:not([onDark])[variant="fareBasicEconomy"]),
+:host(:not([appearance="inverse"])[variant="fareBasicEconomy"]) {
   --ds-auro-icon-color: var(--ds-basic-color-fare-basiceconomy, #{v.$ds-basic-color-fare-basiceconomy});
 }
 
-:host(:not([onDark])[variant="fareBusiness"]) {
+:host(:not([onDark])[variant="fareBusiness"]),
+:host(:not([appearance="inverse"])[variant="fareBusiness"]) {
   --ds-auro-icon-color: var(--ds-basic-color-fare-business, #{v.$ds-basic-color-fare-business});
 }
 
-:host(:not([onDark])[variant="fareEconomy"]) {
+:host(:not([onDark])[variant="fareEconomy"]),
+:host(:not([appearance="inverse"])[variant="fareEconomy"]) {
   --ds-auro-icon-color: var(--ds-basic-color-fare-economy, #{v.$ds-basic-color-fare-economy});
 }
 
-:host(:not([onDark])[variant="fareFirst"]) {
+:host(:not([onDark])[variant="fareFirst"]),
+:host(:not([appearance="inverse"])[variant="fareFirst"]) {
   --ds-auro-icon-color: var(--ds-basic-color-fare-first, #{v.$ds-basic-color-fare-first});
 }
 
-:host(:not([onDark])[variant="farePremiumEconomy"]) {
+:host(:not([onDark])[variant="farePremiumEconomy"]),
+:host(:not([appearance="inverse"])[variant="farePremiumEconomy"]) {
   --ds-auro-icon-color: var(--ds-basic-color-fare-premiumeconomy, #{v.$ds-basic-color-fare-premiumeconomy});
 }
 
 /* OneWorld Alliance Colors */
-:host(:not([onDark])[variant="tierOneWorldEmerald"]) {
+:host(:not([onDark])[variant="tierOneWorldEmerald"]),
+:host(:not([appearance="inverse"])[variant="tierOneWorldEmerald"]) {
   --ds-auro-icon-color: var(--ds-basic-color-tier-program-oneworld-emerald, #{v.$ds-basic-color-tier-program-oneworld-emerald});
 }
 
-:host(:not([onDark])[variant="tierOneWorldSapphire"]) {
+:host(:not([onDark])[variant="tierOneWorldSapphire"]),
+:host(:not([appearance="inverse"])[variant="tierOneWorldSapphire"]) {
   --ds-auro-icon-color: var(--ds-basic-color-tier-program-oneworld-sapphire, #{v.$ds-basic-color-tier-program-oneworld-sapphire});
 }
 
-:host(:not([onDark])[variant="tierOneWorldRuby"]) {
+:host(:not([onDark])[variant="tierOneWorldRuby"]),
+:host(:not([appearance="inverse"])[variant="tierOneWorldRuby"]) {
   --ds-auro-icon-color: var(--ds-basic-color-tier-program-oneworld-ruby, #{v.$ds-basic-color-tier-program-oneworld-ruby});
 }
 
 /* Support for dark mode */
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
 }
 
-:host([onDark][variant="disabled"]) {
+:host([onDark][variant="disabled"]),
+:host([appearance="inverse"][variant="disabled"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse-disabled, #{v.$ds-basic-color-texticon-inverse-disabled});
 }
 
-:host([onDark][variant="muted"]) {
+:host([onDark][variant="muted"]),
+:host([appearance="inverse"][variant="muted"]) {
   --ds-auro-icon-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
 }
 
-:host([onDark][variant="statusError"]) {
+:host([onDark][variant="statusError"]),
+:host([appearance="inverse"][variant="statusError"]) {
   --ds-auro-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `default`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a new `surface` attribute for icon components to replace the deprecated `onDark` flag, update component code and CSS selectors for backward compatibility, and refresh all examples and documentation accordingly while updating package configuration and dependencies.

New Features:
- Add `surface` attribute to control light or dark backgrounds for icons

Enhancements:
- Deprecate `onDark` attribute and maintain backward-compatible CSS selectors for `surface="dark"`
- Extend BaseIcon component with `surface` property defaulting to 'light' and reflect it
- Replace `onDark` usage with `surface="dark"` across demos, examples, and documentation
- Update API table to mark `onDark` as deprecated and document the new `surface` attribute

Chores:
- Add `type: "module"` to package.json and bump dev dependencies for icons, design-tokens, and webcorestylesheets