### PR TITLE
fix: remove hardcoded line-height to align vertically middle #200

### DIFF
--- a/apiExamples/mixMatchTypography.html
+++ b/apiExamples/mixMatchTypography.html
@@ -1,0 +1,26 @@
+
+<auro-icon category="interface" name="chevron-right" label>Icon with body-default slot (Recommended)</span></auro-icon>
+<div class="body-default"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of body-default container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="body-default">Icon next to body-default text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" label class="heading-lg">Icon with heading-lg slot (Recommended)</auro-icon>
+<div class="heading-lg"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of heading-lg container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="heading-lg">Icon next to heading-lg text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" label class="body-xs">Icon with body-xs slot (Recommended)</auro-icon>
+<div class="body-xs"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of body-xs container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="body-xs">Icon next to body-xs text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 3rem" label>Big icon with slotted text (Recommended)</auro-icon>
+<div><auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 3rem"></auro-icon>Big icon next to text</div>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 0.8rem" label>Small icon with slotted text (Recommended)</auro-icon>
+<div><auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 0.8rem"></auro-icon>Small icon next to text</div>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -35,9 +35,12 @@ Using the `customSvg` attribute, the component may render any icon svg content r
 
 </auro-accordion>
 
-### Default component with label (accessibility recommendation)
+### Default component with label (accessibility recommendation) <a name="label"></a>
 
-While you may place the icon alone, it is considered best practice to combine the icon with a description statement. The `auro-icon` element easily supports this with the use of the `label` attribute. By using the `label` attribute, content you enter into the `slot` of the element will appear next to the icon of choice. Changing the `aria-hidden` state of the icon is NOT needed. The assistive technologies will bypass the icon and announce the label string of content.
+While you may place the icon alone, it is considered best practice to combine the icon with a description statement.
+The `auro-icon` element easily supports this with the use of the `label` attribute.
+By using the `label` attribute, content you enter into the `slot` of the element will appear next to the icon of choice.
+Changing the `aria-hidden` state of the icon is NOT needed. The assistive technologies will bypass the icon and announce the label string of content.
 
 In situations where the icon is to be listed with a descriptive label, simply use the `label` attribute and the text in the `slot` will appear next to the icon.
 
@@ -50,6 +53,25 @@ In situations where the icon is to be listed with a descriptive label, simply us
   <span slot="trigger">See code</span>
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/accessRec.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+### label with typography classes
+
+When using the `label` attribute, you may apply typography classes to the `slot` element to match your design system needs.
+
+Below is an example of mixing and matching typography styles with the `auro-icon` component.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/mixMatchTypography.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/mixMatchTypography.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -17,7 +17,6 @@
 :host {
   color: currentColor;
   vertical-align: middle;
-  line-height: 1;
   display: inline-block;
 }
 
@@ -29,14 +28,24 @@ svg {
 
 .componentWrapper {
   display: flex;
+  line-height: var(--ds-auro-icon-size);
 }
 
 .svgWrapper {
   height: var(--ds-auro-icon-size);
   width: var(--ds-auro-icon-size);
+
+  [part="svg"] {
+    display: flex;
+  }
 }
 
 .labelWrapper {
   margin-left: var(--ds-size-50, vac.$ds-size-50);
-  line-height: 1.8;
+
+  ::slotted(*) {
+    // This is to make the icon and label vertically align properly in the middle
+    line-height: inherit !important; // stylelint-disable-line declaration-no-important
+  }
 }
+


### PR DESCRIPTION
# Alaska Airlines Pull Request

When the line height of the label is smaller or taller than the icon size, the vertical alignment was breaking. 
This is to fix the vertical alignment to be properly in the middle of the first line of the label. 

| Before | After |
| ---- | ---- |
|  <img width="659" height="647" alt="image" src="https://github.com/user-attachments/assets/72e68cdd-14cc-4541-ad48-73007ffa1d38" /> |   <img width="652" height="587" alt="image" src="https://github.com/user-attachments/assets/74ec89ad-b733-466f-86d6-d55b1c916d58" /> |


closes #200 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix icon-label vertical alignment by removing hardcoded line-heights, inheriting slot content line-height, and adjusting component styles, and update documentation with a new typography example section.

Enhancements:
- Remove hardcoded line-height and inherit slotted content’s line-height for proper icon-label vertical centering
- Adjust component styles by setting wrapper line-height to icon size and enabling flex display on the SVG part

Documentation:
- Add anchor and restructure paragraphs in API docs for label usage
- Introduce “label with typography classes” section and provide mix-and-match examples in a new example file