### PR TITLE
RC 2025-10-29

### DIFF
--- a/apiExamples/mixMatchTypography.html
+++ b/apiExamples/mixMatchTypography.html
@@ -1,0 +1,26 @@
+
+<auro-icon category="interface" name="chevron-right" label>Icon with body-default slot (Recommended)</span></auro-icon>
+<div class="body-default"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of body-default container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="body-default">Icon next to body-default text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" label class="heading-lg">Icon with heading-lg slot (Recommended)</auro-icon>
+<div class="heading-lg"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of heading-lg container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="heading-lg">Icon next to heading-lg text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" label class="body-xs">Icon with body-xs slot (Recommended)</auro-icon>
+<div class="body-xs"><auro-icon category="interface" name="chevron-right"></auro-icon>Icon inside of body-xs container</div>
+<auro-icon category="interface" name="chevron-right"></auro-icon><span class="body-xs">Icon next to body-xs text</span>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 3rem" label>Big icon with slotted text (Recommended)</auro-icon>
+<div><auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 3rem"></auro-icon>Big icon next to text</div>
+
+<br><br>
+
+<auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 0.8rem" label>Small icon with slotted text (Recommended)</auro-icon>
+<div><auro-icon category="interface" name="chevron-right" style="--ds-auro-icon-size: 0.8rem"></auro-icon>Small icon next to text</div>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -35,9 +35,12 @@ Using the `customSvg` attribute, the component may render any icon svg content r
 
 </auro-accordion>
 
-### Default component with label (accessibility recommendation)
+### Default component with label (accessibility recommendation) <a name="label"></a>
 
-While you may place the icon alone, it is considered best practice to combine the icon with a description statement. The `auro-icon` element easily supports this with the use of the `label` attribute. By using the `label` attribute, content you enter into the `slot` of the element will appear next to the icon of choice. Changing the `aria-hidden` state of the icon is NOT needed. The assistive technologies will bypass the icon and announce the label string of content.
+While you may place the icon alone, it is considered best practice to combine the icon with a description statement.
+The `auro-icon` element easily supports this with the use of the `label` attribute.
+By using the `label` attribute, content you enter into the `slot` of the element will appear next to the icon of choice.
+Changing the `aria-hidden` state of the icon is NOT needed. The assistive technologies will bypass the icon and announce the label string of content.
 
 In situations where the icon is to be listed with a descriptive label, simply use the `label` attribute and the text in the `slot` will appear next to the icon.
 
@@ -50,6 +53,25 @@ In situations where the icon is to be listed with a descriptive label, simply us
   <span slot="trigger">See code</span>
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/accessRec.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+### label with typography classes
+
+When using the `label` attribute, you may apply typography classes to the `slot` element to match your design system needs.
+
+Below is an example of mixing and matching typography styles with the `auro-icon` component.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/mixMatchTypography.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/mixMatchTypography.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -17,7 +17,6 @@
 :host {
   color: currentColor;
   vertical-align: middle;
-  line-height: 1;
   display: inline-block;
 }
 
@@ -29,14 +28,24 @@ svg {
 
 .componentWrapper {
   display: flex;
+  line-height: var(--ds-auro-icon-size);
 }
 
 .svgWrapper {
   height: var(--ds-auro-icon-size);
   width: var(--ds-auro-icon-size);
+
+  [part="svg"] {
+    display: flex;
+  }
 }
 
 .labelWrapper {
   margin-left: var(--ds-size-50, vac.$ds-size-50);
-  line-height: 1.8;
+
+  ::slotted(*) {
+    // This is to make the icon and label vertically align properly in the middle
+    line-height: inherit !important; // stylelint-disable-line declaration-no-important
+  }
 }
+


### PR DESCRIPTION
## RC Summary

- fix 293b592 | 2025-10-23 | Eunsun Mota
fix: remove hardcoded line-height to align vertically middle
#200

## Summary by Sourcery

Remove hardcoded line-height in the auro-icon component to fix vertical alignment and update API documentation with a new section showcasing typography class usage and examples.

Bug Fixes:
- Remove fixed line-height rules in component styles to ensure icons and labels align vertically centered

Enhancements:
- Refactor CSS to leverage flex layouts and inheritable line-height for slotted label content
- Introduce display flex on the SVG part and synchronize wrapper line-height with icon size variable

Documentation:
- Add anchor link and restructure the default label section in API docs
- Add a new “label with typography classes” section with mix-and-match examples (mixMatchTypography.html)