### PR TITLE
Update broken link in API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,14 +8,14 @@ auro-icon provides users a way to use the Auro Icons by simply passing in the ca
 |------------------|------------------|-----------|-------------|--------------------------------------------------|
 | `appearance`     | `appearance`     | `string`  | "'default'" | Defines whether the button will be on lighter or darker backgrounds. |
 | `ariaHidden`     | `ariaHidden`     | `string`  |             | Set aria-hidden value. Default is `true`. Option is `false`. |
-| `category`       | `category`       | `string`  |             | The category of the icon you are looking for. See https://auro.alaskaair.com/icons/usage. |
+| `category`       | `category`       | `string`  |             | The category of the icon you are looking for. See https://auro.alaskaair.com/icons/ways-to-use. |
 | `customColor`    | `customColor`    | `boolean` |             | Allows custom color to be set.                   |
 | `customSvg`      | `customSvg`      | `boolean` |             | When true, auro-icon will render a custom SVG inside the default slot. |
 | `hidden`         | `hidden`         | `Boolean` |             | If present, the component will be hidden both visually and from screen readers |
 | `hiddenAudible`  | `hiddenAudible`  | `Boolean` |             | If present, the component will be hidden from screen readers, but seen visually |
 | `hiddenVisually` | `hiddenVisually` | `Boolean` |             | If present, the component will be hidden visually, but still read by screen readers |
 | `label`          | `label`          | `boolean` |             | Exposes content in slot as icon label.           |
-| `name`           | `name`           | `string`  |             | The name of the icon you are looking for without the file extension. See https://auro.alaskaair.com/icons/usage. |
+| `name`           | `name`           | `string`  |             | The name of the icon you are looking for without the file extension. See https://auro.alaskaair.com/icons/ways-to-use. |
 | `onDark`         | `onDark`         | `boolean` | false       | DEPRECATED - use `appearance` instead.           |
 | `variant`        | `variant`        | `string`  | "undefined" | The style of the icon. The accepted variants are `accent1`, `disabled`, `muted`, `statusDefault`, `statusInfo`, `statusSuccess`, `statusWarning`, `statusError`, `statusInfoSubtle`, `statusSuccessSubtle`, `statusWarningSubtle`, `statusErrorSubtle`, `fareBasicEconomy`, `fareBusiness`, `fareEconomy`, `fareFirst`, `farePremiumEconomy`, `tierOneWorldEmerald`, `tierOneWorldSapphire`, `tierOneWorldRuby`. |
 

--- a/src/auro-icon.js
+++ b/src/auro-icon.js
@@ -49,7 +49,7 @@ export class AuroIcon extends BaseIcon {
       },
 
       /**
-       * The category of the icon you are looking for. See https://auro.alaskaair.com/icons/usage.
+       * The category of the icon you are looking for. See https://auro.alaskaair.com/icons/ways-to-use.
        */
       category: {
         type: String,
@@ -80,7 +80,7 @@ export class AuroIcon extends BaseIcon {
       },
 
       /**
-       * The name of the icon you are looking for without the file extension. See https://auro.alaskaair.com/icons/usage.
+       * The name of the icon you are looking for without the file extension. See https://auro.alaskaair.com/icons/ways-to-use.
        */
       name: {
         type: String,


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix the broken icons usage link by updating references to the correct ‘ways-to-use’ URL in both API documentation and code comments

Documentation:
- Update docs/api.md to replace the outdated /icons/usage link with /icons/ways-to-use
- Correct JSDoc comment in src/auro-icon.js to reference the new /icons/ways-to-use URL